### PR TITLE
fix `switch` type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,7 @@ declare global {
     children?: {}
     each?: unknown[]
     when?: boolean
-    switch?: void
+    switch?: void | boolean
     provide?: {
       id: symbol
       initFn: () => any


### PR DESCRIPTION
When declaring an empty attribute like `<$ switch />` it is treated as `<$ switch={ true } />`. Regarding this PR: we could also explicitly declare it as `true` instead of `boolean`?