### PR TITLE
Adjusted forwardRef to be callback

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,7 +52,7 @@ declare global {
     // https://github.com/ryansolid/babel-plugin-jsx-dom-expressions#special-binding
     interface CustomAttributes<T> {
       ref?: T
-      forwardRef?: T
+      forwardRef?: (el: T) => void
       classList?: { [k: string]: boolean | undefined }
       events?: { [key: string]: EventHandler<T, CustomEvent> }
     }


### PR DESCRIPTION
I still don't understand what a `forwardRef` is semantically. According to the type definitions it is the same as a `ref`, but in #14 you mentioned it is a callback. Does this just need an adjustment of the type definition here?