### PR TITLE
Proposal for adapting the JSX.Element type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+type DomElement = Element;  // Introduce alias due to shadowing in JSX namespace.
+
 declare global {
   /**
    * Forked from `https://github.com/adamhaile/surplus` and adapted for `babel-plugin-jsx-dom-expressions`.
@@ -7,7 +9,12 @@ declare global {
    */
 
   namespace JSX {
-    interface Element extends HTMLElement {}
+    type Element = DomElement | ArrayElement | FunctionElement;
+
+    interface ArrayElement extends Array<Element> {}
+    interface FunctionElement {
+      (): Element;
+    }
 
     // Let TS know the name of the `children` property in order for it to be able to type check them.
     // https://github.com/Microsoft/TypeScript/issues/18357

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,11 +9,15 @@ declare global {
    */
 
   namespace JSX {
-    type Element = DomElement | ArrayElement | FunctionElement;
+    type Element = DomElement | ArrayElement | FunctionElement | MatchElement | string | number;
 
     interface ArrayElement extends Array<Element> {}
     interface FunctionElement {
-      (): Element;
+      (): Element
+    }
+    interface MatchElement {
+      when: boolean
+      children: Element
     }
 
     // Let TS know the name of the `children` property in order for it to be able to type check them.


### PR DESCRIPTION
This is a translation of your statement on Gitter into TypeScript:

> we aren't sending back just HTML elements anymore. We can return Arrays or Functions.. eventually everything boils down to strings or HTMLElements. But there may be any level of nested Arrays/function calls in between

The new type allows for such recursions (using [this pattern](https://stackoverflow.com/a/45999529/1804173)). A few examples:

```ts
// The automatically inferred types in all of the following is JSX.Element as desired:
function A() {
  return <div></div>
}

let a1 = <div></div>
let a2 = <A/>
let a3 = <></>

// All of the following compiles, i.e., arbitrary nesting is supported by JSX.Element:
function Explicit1(): JSX.Element {
  return document.createElement("div");
}
function Explicit2(): JSX.Element {
  return [
    document.createElement("div"),
    document.createElement("div"),
  ];
}
function Explicit3(): JSX.Element {
  return () => document.createElement("div");
}
function Explicit4(): JSX.Element {
  return () => [
    document.createElement("div"),
    [
      document.createElement("div"),
      document.createElement("div"),
      () => document.createElement("div"),
    ],
    () => document.createElement("div"),
  ]
}

// As desired, diverging for the supported values results in compile time errors.
// For example, the following errors would be caught by the compiler:
function Rejected1(): JSX.Element {
  return 42;
}

function Rejected2(): JSX.Element {
  return "not a supported JSX element";
}
```

Open questions:

- Does this cover all supported values or is there anything left out?
- What should be the type of the DOM elements, `Node`, `Element` or `HTMLElement`? I went for the `Element` to allow for e.g. `SVGElement` as well.

The follow up step of this would be to basically replace all `any` by `JSX.Element` in [`solid/dom`](https://github.com/ryansolid/solid/blob/master/src/dom/index.ts).