### PR TITLE
Add support for Event.target.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,7 @@ declare global {
       | (() => Child[]);
 
     interface EventHandler<T, E extends Event> {
-      (e: E & { currentTarget: T }): void;
+      (e: E & { currentTarget: T, target: T }): void;
     }
 
     // Intrinsic attributes enable us to define certain keys as attributes on an element, while


### PR DESCRIPTION
1. Previously using Event.target.value with and input resulted in a warning that EventTarget did not have property value. EventTarget was not recongizing that it was an HTMLInputElement. Adding target to the EventHandler forces TypeScript to recognize that target of event on HTMLInputElement has a property "value".