### PR TITLE
Add support for Pointer Events

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,8 +159,8 @@ declare global {
       onpointermove?: EventHandler<T, Event>;
       onPointerOver?: EventHandler<T, Event>;
       onpointerover?: EventHandler<T, Event>;
-      onpointerout?: EventHandler<T, Event>;
       onPointerOut?: EventHandler<T, Event>;
+      onpointerout?: EventHandler<T, Event>;
       onPointerUp?: EventHandler<T, Event>;
       onpointerup?: EventHandler<T, Event>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -161,8 +161,8 @@ declare global {
       onpointerover?: EventHandler<T, Event>;
       onpointerout?: EventHandler<T, Event>;
       onPointerOut?: EventHandler<T, Event>;
-      onpointerup?: EventHandler<T, Event>;
       onPointerUp?: EventHandler<T, Event>;
+      onpointerup?: EventHandler<T, Event>;
 
       // Media Events
       onAbort?: EventHandler<T, Event>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,6 +142,28 @@ declare global {
       onKeyUpCapture?: EventHandler<T, KeyboardEvent>;
       onkeyupcapture?: EventHandler<T, KeyboardEvent>;
 
+      // Pointer Events
+      onGotPointerCapture?: EventHandler<T, Event>;
+      ongotpointercapture?: EventHandler<T, Event>;
+      onLostPointerCapture?: EventHandler<T, Event>;
+      onlostpointercapture?: EventHandler<T, Event>;
+      onPointerCancel?: EventHandler<T, Event>;
+      onpointercancel?: EventHandler<T, Event>;
+      onPointerDown?: EventHandler<T, Event>;
+      onpointerdown?: EventHandler<T, Event>;
+      onPointerEnter?: EventHandler<T, Event>;
+      onpointerenter?: EventHandler<T, Event>;
+      onPointerLeave?: EventHandler<T, Event>;
+      onpointerleave?: EventHandler<T, Event>;
+      onPointerMove?: EventHandler<T, Event>;
+      onpointermove?: EventHandler<T, Event>;
+      onPointerOver?: EventHandler<T, Event>;
+      onpointerover?: EventHandler<T, Event>;
+      onpointerout?: EventHandler<T, Event>;
+      onPointerOut?: EventHandler<T, Event>;
+      onpointerup?: EventHandler<T, Event>;
+      onPointerUp?: EventHandler<T, Event>;
+
       // Media Events
       onAbort?: EventHandler<T, Event>;
       onabort?: EventHandler<T, Event>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -393,7 +393,7 @@ declare global {
       coords?: string;
       crossorigin?: string;
       data?: string;
-      dataSet?: string;
+      dataset?: string;
       dateTime?: string;
       default?: boolean;
       defer?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -393,6 +393,7 @@ declare global {
       coords?: string;
       crossorigin?: string;
       data?: string;
+      dataSet?: string;
       dateTime?: string;
       default?: boolean;
       defer?: boolean;


### PR DESCRIPTION
All currently shipping browsers support Pointer Events, including Safari 13.
This adds support for them.